### PR TITLE
Add FIVETRAN_SYNCED validation tests

### DIFF
--- a/tests/test_fivetran_synced.py
+++ b/tests/test_fivetran_synced.py
@@ -1,0 +1,40 @@
+import ast
+import inspect
+
+import pytest
+
+from mapper_fivetran import SystemColumns
+from mapper_fivetran.mapper import FIVETRAN_SYNCED, FivetranStreamMap
+
+
+def test_constant_matches_system_column():
+    """FIVETRAN_SYNCED should match the enum value."""
+    assert FIVETRAN_SYNCED == SystemColumns.FIVETRAN_SYNCED.value
+
+
+def test_transform_assigns_iso_timestamp():
+    """Verify `transform` assigns an ISO8601 timestamp to the synced column."""
+    source = inspect.getsource(FivetranStreamMap.transform)
+    tree = ast.parse(source)
+    found = False
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Assign) and len(node.targets) == 1:
+            target = node.targets[0]
+            if (
+                isinstance(target, ast.Subscript)
+                and isinstance(target.value, ast.Name)
+                and target.value.id == "record"
+            ):
+                slice_node = target.slice
+                if isinstance(slice_node, ast.Name) and slice_node.id == "FIVETRAN_SYNCED":
+                    if (
+                        isinstance(node.value, ast.Call)
+                        and isinstance(node.value.func, ast.Attribute)
+                        and node.value.func.attr == "isoformat"
+                        and isinstance(node.value.func.value, ast.Call)
+                        and isinstance(node.value.func.value.func, ast.Name)
+                        and node.value.func.value.func.id == "utc_now"
+                    ):
+                        found = True
+                        break
+    assert found, "transform should assign utc_now().isoformat() to FIVETRAN_SYNCED"

--- a/tests/test_fivetran_synced.py
+++ b/tests/test_fivetran_synced.py
@@ -14,9 +14,9 @@ def test_constant_matches_system_column():
 def test_transform_adds_timestamp_column():
     """transform() should add an ISO timestamp in `FIVETRAN_SYNCED`."""
     stream_map = FivetranStreamMap(
-        stream_alias="animals",
-        schema={"properties": {}},
-        key_properties=[],
+        "animals",
+        {"properties": {}},
+        [],
     )
 
     out = stream_map.transform({"name": "Otis"})

--- a/tests/test_fivetran_synced.py
+++ b/tests/test_fivetran_synced.py
@@ -22,4 +22,9 @@ def test_transform_adds_timestamp_column():
     out = stream_map.transform({"name": "Otis"})
 
     assert FIVETRAN_SYNCED in out
-    datetime.fromisoformat(out[FIVETRAN_SYNCED])
+
+    timestamp = out[FIVETRAN_SYNCED]
+    parsed = datetime.fromisoformat(timestamp)
+
+    assert parsed.isoformat() == timestamp
+    assert parsed.tzinfo is not None


### PR DESCRIPTION
## Summary
- add tests to check FIVETRAN_SYNCED constant and transform behaviour

## Testing
- `uv run pytest -q tests/test_fivetran_synced.py` *(fails: Failed to download `python-dotenv==1.0.1`)*

------
https://chatgpt.com/codex/tasks/task_b_6871220ed51c8321b49fbaed8189eaf0